### PR TITLE
Fixes toolbar overlap to page title

### DIFF
--- a/src/components/Toolbar/Toolbar.scss
+++ b/src/components/Toolbar/Toolbar.scss
@@ -84,5 +84,5 @@
 .actions {
   position: absolute;
   right: 14px;
-  bottom: 14px;
+  top: 0;
 }


### PR DESCRIPTION
Resolves #1577

<img width="499" alt="Снимок экрана 2020-07-27 в 1 23 30" src="https://user-images.githubusercontent.com/545151/88520751-d9938300-cfa8-11ea-8d45-97ab4cc031cf.png">
<img width="815" alt="Снимок экрана 2020-07-27 в 1 23 42" src="https://user-images.githubusercontent.com/545151/88521616-fed4c100-cfa9-11ea-9033-40687a4a4ae2.png">

